### PR TITLE
fix linux build

### DIFF
--- a/ESP32 Zigbee/src/main.cpp
+++ b/ESP32 Zigbee/src/main.cpp
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #include <WiFi.h>
-#include <WifiManager.h>
+#include <WiFiManager.h>
 #include <time.h>
 
 #include "flasher.h"


### PR DESCRIPTION
so uh, since most linux FS are case sensitive, you were not able to build this project on linux, because the library header file is actually called WiFiManager not Wifimanager. This PR is supposed to fix it